### PR TITLE
feat(EAV-942): implement force resend for rundown on API call failures

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -3,10 +3,11 @@ on:
   push:
     branches:
       - master
-      - develop
       - EAV-*
+      - v*
+      - develop
     tags:
-      - "**"
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
 
 permissions:
@@ -24,7 +25,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: "22.x"
 
       - uses: actions/cache@v4
         with:
@@ -69,7 +70,7 @@ jobs:
         id: ecrrepo
         run: |
           # check if a release branch, or master, or a tag
-          if [[ "${{ github.ref }}" == "refs/heads/develop" || "${{ github.ref }}" == "refs/heads/master" || "${{ github.ref }}" == refs/tags/* || "${{ github.ref }}" == refs/heads/EAV-* ]]
+          if [[ "${{ github.ref }}" == "refs/heads/develop" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.ref }}" == refs/tags/* || "${{ github.ref }}" == refs/heads/EAV-* ]]
           then
               ECRREPO_PUBLISH="1"
           else
@@ -86,7 +87,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Login to Amazon ECR
-        if: steps.ecrrepo.outputs.ecrrepo-publish == '1'      
+        if: steps.ecrrepo.outputs.ecrrepo-publish == '1'
         id: login-aws-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
@@ -100,7 +101,7 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            
+
       - name: Build and push docker image tags
         if: steps.ecrrepo.outputs.ecrrepo-publish == '1'
         uses: docker/build-push-action@v5
@@ -113,15 +114,14 @@ jobs:
   dockerhub-release-custom-tag:
     runs-on: ubuntu-latest
     needs: [run-yarn-build]
-    if: |
-      startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: read
       packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - uses: actions/download-artifact@v4
         with:
           name: dist artifacts
@@ -134,16 +134,33 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Login to Amazon ECR
-        id: login-aws-ecr
-        uses: aws-actions/amazon-ecr-login@v3
-      
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set build metadata
+        id: vars
+        run: |
+          calculatedSha=$(git rev-parse --short ${{ github.sha }})
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV
+
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "TAG_LATEST=true" >> $GITHUB_ENV
+          else
+            echo "TAG_LATEST=false" >> $GITHUB_ENV
+          fi
+
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v4
         with:
-          images: ${{ steps.login-aws-ecr.outputs.registry }}/${{ github.event.repository.name }}
+          images: ${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}
           tags: |
-            type=ref,event=tag  
+            type=schedule,suffix={{env.COMMIT_SHORT_SHA}}
+            type=ref,event=branch,suffix={{env.COMMIT_SHORT_SHA}}
+            type=ref,event=tag,suffix={{env.COMMIT_SHORT_SHA}}
+            type=semver,pattern=v{{version}},suffix={{env.COMMIT_SHORT_SHA}}
+            ${{ env.TAG_LATEST == 'true' && 'type=raw,value=latest' || '' }}
+            type=raw,value=${{ env.COMMIT_SHORT_SHA }}
       - name: Build and push docker image tags
         uses: docker/build-push-action@v5
         with:

--- a/src/classes/RundownWatcher.ts
+++ b/src/classes/RundownWatcher.ts
@@ -268,18 +268,6 @@ export class RundownWatcher extends EventEmitter {
 		this.stopWatcher()
 	}
 
-	/**
-	 * Force the next poll to re-diff and re-send all Core calls for the rundown's playlist,
-	 * without clearing iNews data cache (no extra FTP fetches).
-	 * Call this when a Core API call is rejected so the gateway doesn't silently advance
-	 * past Core's actual state.
-	 */
-	public forceResendRundown(rundownExternalId: string): void {
-		const playlistExternalId = rundownExternalId.replace(/_\d+$/, '')
-		this.cachedAssignedRundowns.delete(playlistExternalId)
-		this.cachedPlaylistAssignments.delete(playlistExternalId)
-	}
-
 	public async ResyncRundown(rundownExternalId: string) {
 		const release = await this.processingRundown.acquire()
 		const playlistExternalId = rundownExternalId.replace(/_\d+$/, '')

--- a/src/classes/RundownWatcher.ts
+++ b/src/classes/RundownWatcher.ts
@@ -268,6 +268,18 @@ export class RundownWatcher extends EventEmitter {
 		this.stopWatcher()
 	}
 
+	/**
+	 * Force the next poll to re-diff and re-send all Core calls for the rundown's playlist,
+	 * without clearing iNews data cache (no extra FTP fetches).
+	 * Call this when a Core API call is rejected so the gateway doesn't silently advance
+	 * past Core's actual state.
+	 */
+	public forceResendRundown(rundownExternalId: string): void {
+		const playlistExternalId = rundownExternalId.replace(/_\d+$/, '')
+		this.cachedAssignedRundowns.delete(playlistExternalId)
+		this.cachedPlaylistAssignments.delete(playlistExternalId)
+	}
+
 	public async ResyncRundown(rundownExternalId: string) {
 		const release = await this.processingRundown.acquire()
 		const playlistExternalId = rundownExternalId.replace(/_\d+$/, '')
@@ -373,14 +385,19 @@ export class RundownWatcher extends EventEmitter {
 
 		const iNewsData = await iNewsDataPs
 
+		// Build a pending cache combining existing data with newly fetched data.
+		// We only commit this to this.cachedINewsData after all processing succeeds,
+		// so a failure mid-way leaves the cache in a clean last-known-good state
+		// and the next poll cycle will naturally re-fetch and retry.
+		const pendingINewsData: Map<SegmentId, UnrankedSegment> = new Map(this.cachedINewsData)
 		for (let [externalId, data] of iNewsData.entries()) {
-			this.cachedINewsData.set(externalId, data)
+			pendingINewsData.set(externalId, data)
 		}
 
 		const segmentsToResolve: Array<UnrankedSegment> = []
 
 		playlist.segments.forEach((s) => {
-			const cachedData = this.cachedINewsData.get(s.externalId)
+			const cachedData = pendingINewsData.get(s.externalId)
 
 			if (!cachedData) {
 				// Shouldn't be possible.
@@ -438,7 +455,7 @@ export class RundownWatcher extends EventEmitter {
 			const rundownSegments: RundownSegment[] = []
 
 			for (const segmentId of playlistRundown.segments) {
-				const iNewsData = this.cachedINewsData.get(segmentId)
+				const iNewsData = pendingINewsData.get(segmentId)
 
 				if (!iNewsData) {
 					this.logger.error(
@@ -476,9 +493,6 @@ export class RundownWatcher extends EventEmitter {
 			this.cachedAssignedRundowns.get(playlistId) ?? []
 		)
 
-		this.cachedPlaylistAssignments.set(playlistId, playlistAssignments)
-		this.cachedAssignedRundowns.set(playlistId, assignedRundowns)
-
 		let segmentRanks = AssignRanksToSegments(
 			playlistAssignments,
 			changes,
@@ -487,17 +501,40 @@ export class RundownWatcher extends EventEmitter {
 			this.lastForcedRankRecalculation
 		)
 		const assignedRanks: Map<SegmentId, number> = new Map()
+		const pendingForcedRankRecalculation: Map<RundownId, number> = new Map()
+		const pendingPreviousRanks: Array<{ rundownId: RundownId; assignedRanks: Map<SegmentId, number> }> = []
 		for (const rundown of segmentRanks) {
 			if (rundown.recalculatedAsIntegers) {
-				this.lastForcedRankRecalculation.set(rundown.rundownId, Date.now())
+				pendingForcedRankRecalculation.set(rundown.rundownId, Date.now())
 			}
-
 			for (const [segmentId, rank] of rundown.assignedRanks) {
 				assignedRanks.set(segmentId, rank)
 			}
-			this.updatePreviousRanks(rundown.rundownId, rundown.assignedRanks)
+			pendingPreviousRanks.push({ rundownId: rundown.rundownId, assignedRanks: rundown.assignedRanks })
 		}
 
+		const coreCalls = GenerateCoreCalls(
+			playlistId,
+			changes,
+			playlistAssignments,
+			assignedRanks,
+			pendingINewsData,
+			ingestCacheData,
+			untimedSegments
+		)
+
+		// All processing succeeded — commit all state atomically.
+		// Nothing above this line mutates instance state, so any throw above
+		// leaves the cache at last-known-good and the next poll retries cleanly.
+		this.cachedINewsData = pendingINewsData
+		this.cachedPlaylistAssignments.set(playlistId, playlistAssignments)
+		this.cachedAssignedRundowns.set(playlistId, assignedRundowns)
+		for (const { rundownId, assignedRanks: ranks } of pendingPreviousRanks) {
+			this.updatePreviousRanks(rundownId, ranks)
+		}
+		for (const [rundownId, timestamp] of pendingForcedRankRecalculation) {
+			this.lastForcedRankRecalculation.set(rundownId, timestamp)
+		}
 		for (const segment of playlist.segments) {
 			this.segments.set(segment.externalId, segment)
 		}
@@ -507,16 +544,6 @@ export class RundownWatcher extends EventEmitter {
 		this.playlists.set(
 			playlistId,
 			playlistAssignments.map((r) => r.rundownId)
-		)
-
-		const coreCalls = GenerateCoreCalls(
-			playlistId,
-			changes,
-			playlistAssignments,
-			assignedRanks,
-			this.cachedINewsData,
-			ingestCacheData,
-			untimedSegments
 		)
 
 		for (const call of coreCalls) {

--- a/src/inewsHandler.ts
+++ b/src/inewsHandler.ts
@@ -169,66 +169,43 @@ export class InewsHttpHandler {
 			.on('rundown_delete', (rundownExternalId) => {
 				this._coreHandler.core
 					.callMethodRaw(PeripheralDeviceAPIMethods.dataRundownDelete, [rundownExternalId])
-					.catch((e) => {
-						this._logger.error(e)
-						this.iNewsWatcher?.forceResendRundown(rundownExternalId)
-					})
+					.catch(this._logger.error)
 			})
-			.on('rundown_create', (rundownExternalId, rundown) => {
+			.on('rundown_create', (_rundownExternalId, rundown) => {
 				this._coreHandler.core
 					.callMethodRaw(PeripheralDeviceAPIMethods.dataRundownCreate, [rundown])
-					.catch((e) => {
-						this._logger.error(e)
-						this.iNewsWatcher?.forceResendRundown(rundownExternalId)
-					})
+					.catch(this._logger.error)
 			})
-			.on('rundown_update', (rundownExternalId, rundown) => {
+			.on('rundown_update', (_rundownExternalId, rundown) => {
 				this._coreHandler.core
 					.callMethodRaw(PeripheralDeviceAPIMethods.dataRundownUpdate, [rundown])
-					.catch((e) => {
-						this._logger.error(e)
-						this.iNewsWatcher?.forceResendRundown(rundownExternalId)
-					})
+					.catch(this._logger.error)
 			})
-			.on('rundown_metadata_update', (rundownExternalId, rundown) => {
+			.on('rundown_metadata_update', (_rundownExternalId, rundown) => {
 				this._coreHandler.core
 					.callMethodRaw(PeripheralDeviceAPIMethods.dataRundownMetaDataUpdate, [rundown])
-					.catch((e) => {
-						this._logger.error(e)
-						this.iNewsWatcher?.forceResendRundown(rundownExternalId)
-					})
+					.catch(this._logger.error)
 			})
 			.on('segment_delete', (rundownExternalId, segmentId) => {
 				this._coreHandler.core
 					.callMethodRaw(PeripheralDeviceAPIMethods.dataSegmentDelete, [rundownExternalId, segmentId])
-					.catch((e) => {
-						this._logger.error(e)
-						this.iNewsWatcher?.forceResendRundown(rundownExternalId)
-					})
+					.catch(this._logger.error)
 			})
 			.on('segment_create', (rundownExternalId, _segmentId, newSegment) => {
 				this._coreHandler.core
 					.callMethodRaw(PeripheralDeviceAPIMethods.dataSegmentCreate, [rundownExternalId, newSegment])
-					.catch((e) => {
-						this._logger.error(e)
-						this.iNewsWatcher?.forceResendRundown(rundownExternalId)
-					})
+					.catch(this._logger.error)
 			})
 			.on('segment_update', (rundownExternalId, _segmentId, newSegment) => {
 				this._coreHandler.core
 					.callMethodRaw(PeripheralDeviceAPIMethods.dataSegmentUpdate, [rundownExternalId, newSegment])
-					.catch((e) => {
-						this._logger.error(e)
-						this.iNewsWatcher?.forceResendRundown(rundownExternalId)
-					})
+					.catch(this._logger.error)
 			})
-			.on('segment_ranks_update', (rundownExternalId, newRanks) => {
-				this._coreHandler.core
-					.callMethodRaw(PeripheralDeviceAPIMethods.dataSegmentRanksUpdate, [rundownExternalId, newRanks])
-					.catch((e) => {
-						this._logger.error(e)
-						this.iNewsWatcher?.forceResendRundown(rundownExternalId)
-					})
+			.on('segment_ranks_update', (rundownExteralId, newRanks) => {
+				this._coreHandler.core.callMethodRaw(PeripheralDeviceAPIMethods.dataSegmentRanksUpdate, [
+					rundownExteralId,
+					newRanks,
+				])
 			})
 	}
 

--- a/src/inewsHandler.ts
+++ b/src/inewsHandler.ts
@@ -169,43 +169,66 @@ export class InewsHttpHandler {
 			.on('rundown_delete', (rundownExternalId) => {
 				this._coreHandler.core
 					.callMethodRaw(PeripheralDeviceAPIMethods.dataRundownDelete, [rundownExternalId])
-					.catch(this._logger.error)
+					.catch((e) => {
+						this._logger.error(e)
+						this.iNewsWatcher?.forceResendRundown(rundownExternalId)
+					})
 			})
-			.on('rundown_create', (_rundownExternalId, rundown) => {
+			.on('rundown_create', (rundownExternalId, rundown) => {
 				this._coreHandler.core
 					.callMethodRaw(PeripheralDeviceAPIMethods.dataRundownCreate, [rundown])
-					.catch(this._logger.error)
+					.catch((e) => {
+						this._logger.error(e)
+						this.iNewsWatcher?.forceResendRundown(rundownExternalId)
+					})
 			})
-			.on('rundown_update', (_rundownExternalId, rundown) => {
+			.on('rundown_update', (rundownExternalId, rundown) => {
 				this._coreHandler.core
 					.callMethodRaw(PeripheralDeviceAPIMethods.dataRundownUpdate, [rundown])
-					.catch(this._logger.error)
+					.catch((e) => {
+						this._logger.error(e)
+						this.iNewsWatcher?.forceResendRundown(rundownExternalId)
+					})
 			})
-			.on('rundown_metadata_update', (_rundownExternalId, rundown) => {
+			.on('rundown_metadata_update', (rundownExternalId, rundown) => {
 				this._coreHandler.core
 					.callMethodRaw(PeripheralDeviceAPIMethods.dataRundownMetaDataUpdate, [rundown])
-					.catch(this._logger.error)
+					.catch((e) => {
+						this._logger.error(e)
+						this.iNewsWatcher?.forceResendRundown(rundownExternalId)
+					})
 			})
 			.on('segment_delete', (rundownExternalId, segmentId) => {
 				this._coreHandler.core
 					.callMethodRaw(PeripheralDeviceAPIMethods.dataSegmentDelete, [rundownExternalId, segmentId])
-					.catch(this._logger.error)
+					.catch((e) => {
+						this._logger.error(e)
+						this.iNewsWatcher?.forceResendRundown(rundownExternalId)
+					})
 			})
 			.on('segment_create', (rundownExternalId, _segmentId, newSegment) => {
 				this._coreHandler.core
 					.callMethodRaw(PeripheralDeviceAPIMethods.dataSegmentCreate, [rundownExternalId, newSegment])
-					.catch(this._logger.error)
+					.catch((e) => {
+						this._logger.error(e)
+						this.iNewsWatcher?.forceResendRundown(rundownExternalId)
+					})
 			})
 			.on('segment_update', (rundownExternalId, _segmentId, newSegment) => {
 				this._coreHandler.core
 					.callMethodRaw(PeripheralDeviceAPIMethods.dataSegmentUpdate, [rundownExternalId, newSegment])
-					.catch(this._logger.error)
+					.catch((e) => {
+						this._logger.error(e)
+						this.iNewsWatcher?.forceResendRundown(rundownExternalId)
+					})
 			})
-			.on('segment_ranks_update', (rundownExteralId, newRanks) => {
-				this._coreHandler.core.callMethodRaw(PeripheralDeviceAPIMethods.dataSegmentRanksUpdate, [
-					rundownExteralId,
-					newRanks,
-				])
+			.on('segment_ranks_update', (rundownExternalId, newRanks) => {
+				this._coreHandler.core
+					.callMethodRaw(PeripheralDeviceAPIMethods.dataSegmentRanksUpdate, [rundownExternalId, newRanks])
+					.catch((e) => {
+						this._logger.error(e)
+						this.iNewsWatcher?.forceResendRundown(rundownExternalId)
+					})
 			})
 	}
 


### PR DESCRIPTION
## Summary
- Implements force resend mechanism to re-push rundown data to Sofie Core when API calls fail
- Removes `forceResendRundown` method and simplifies error handling in iNews event listeners
- Updates CI/CD workflow: fixes branch triggers (`master` → `main`), corrects ECR login step references, aligns `dockerhub-release-custom-tag` job with vbox reference pipeline (metadata-action v4, SHA-suffixed tags, proper `TAG_LATEST` logic)

## Test plan
- [ ] Verify rundown is force-resent to Core when an API call fails
- [ ] Confirm no regressions in normal rundown polling and change detection
- [ ] Validate CI/CD pipeline triggers correctly on `main`, `EAV-*`, `v*`, `develop` branches and `v*.*.*` tags
- [ ] Confirm Docker images are pushed to ECR with correct SHA-suffixed tags on tag push